### PR TITLE
Use the latest .NET Core 3.1 SDK

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         - Debug
         - Release
         dotnet:
-        - "3.1.100"
+        - 3.1.x
     name: ${{ matrix.os }} ${{ matrix.dotnet }} ${{ matrix.config }}
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
The GitHub Action `setup-dotnet` now supports using latest version `3.1.x`.

actions/setup-dotnet#23